### PR TITLE
Bump versions, including some fixes to get tests working correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ If `make check` target is successful, developer is good to commit the code to pr
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.14 |
 
 ## Providers
 

--- a/examples/source_from_folder/README.md
+++ b/examples/source_from_folder/README.md
@@ -7,8 +7,8 @@ Demonstrates creating a Lambda Function from a local folder.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.14 |
 
 ## Providers
 
@@ -18,8 +18,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform.registry.launch.nttdata.com/module_primitive/lambda_function/aws | ~> 1.0 |
-| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 1.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../.. | n/a |
+| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
 
 ## Resources
 

--- a/examples/source_from_folder/main.tf
+++ b/examples/source_from_folder/main.tf
@@ -11,11 +11,13 @@
 // limitations under the License.
 
 module "lambda_function" {
-  source  = "terraform.registry.launch.nttdata.com/module_primitive/lambda_function/aws"
-  version = "~> 1.0"
+  source = "../.."
 
   name    = module.resource_names["lambda_function"].minimal_random_suffix
   handler = var.handler
+
+  create = true
+  cors   = { allow_origins = ["*"] }
 
   create_package = var.create_package
   source_path    = var.source_path
@@ -23,7 +25,7 @@ module "lambda_function" {
 
 module "resource_names" {
   source  = "terraform.registry.launch.nttdata.com/module_library/resource_name/launch"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   for_each = var.resource_names_map
 

--- a/examples/source_from_folder/versions.tf
+++ b/examples/source_from_folder/versions.tf
@@ -11,12 +11,12 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.5"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.14"
+      version = "~> 5.14"
     }
   }
 }

--- a/examples/source_from_zip/README.md
+++ b/examples/source_from_zip/README.md
@@ -7,8 +7,8 @@ Demonstrates creating a Lambda Function from a zip file.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.14 |
 
 ## Providers
 
@@ -19,7 +19,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform.registry.launch.nttdata.com/module_primitive/lambda_function/aws | ~> 1.0 |
-| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 1.0 |
+| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
 
 ## Resources
 

--- a/examples/source_from_zip/main.tf
+++ b/examples/source_from_zip/main.tf
@@ -17,13 +17,16 @@ module "lambda_function" {
   name    = module.resource_names["lambda_function"].minimal_random_suffix
   handler = var.handler
 
+  create = true
+  cors   = { allow_origins = ["*"] }
+
   create_package = var.create_package
   zip_file_path  = var.zip_file_path
 }
 
 module "resource_names" {
   source  = "terraform.registry.launch.nttdata.com/module_library/resource_name/launch"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   for_each = var.resource_names_map
 

--- a/examples/source_from_zip/versions.tf
+++ b/examples/source_from_zip/versions.tf
@@ -11,12 +11,12 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.5"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.14"
+      version = "~> 5.14"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,12 +11,12 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.5"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.14"
+      version = "~> 5.14"
     }
   }
 }


### PR DESCRIPTION
Needed to set `create = true` and allow all origins in CORS configuration on the examples before the tests would let me deploy the function. After these changes, `make check` completes successfully.